### PR TITLE
fix: stop generating invalid description fields

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -5,7 +5,7 @@ SPEC=https://ctl.prod.nuon.co/oapi/v3
 #SPEC=http://host.docker.internal:8081/oapi/v3
 
 docker run --rm \
-  -v ${PWD}:/local openapitools/openapi-generator-cli generate \
+  -v ${PWD}:/local openapitools/openapi-generator-cli:latest-release generate \
   -i $SPEC \
   -g python \
   -o /local \


### PR DESCRIPTION
The latest release was generating description field string broken over multiple lines, causing a syntax error.

Pinning to the latest stable version doesn't generate descriptions at all, but generates valid python code. Using "latest-release" should get us the description fields back once the bug is fixed upstream.